### PR TITLE
registering only one test block

### DIFF
--- a/lib/register-conversion-listeners.js
+++ b/lib/register-conversion-listeners.js
@@ -4,10 +4,15 @@ var STORED_CONVERSIONS = require('./constants').STORED_CONVERSIONS;
 
 function registerConversionListeners($root, tests, storage) {
   var containers = $root.find('*[data-ab]').toArray();
+  var registeredTests = [];
+  
   containers.map(function(c) {
     var $container = $(c);
     var testInfo = $container.data('ab').split(':');
     var testName = testInfo[0], variantName = testInfo[1];
+
+    if(registeredTests.indexOf(testName) !== -1) return; //if there are two elements that belong to one variant of the test -> don't register rest of them
+    registeredTests.push(testName);
 
     var conversion;
     tests.map(function(t) {


### PR DESCRIPTION
Changes enable such tests when we have more than one block for test per variant. Without those few lines sabot registered conversion for every block which caused doubled or even tripled conversions.